### PR TITLE
fixed registering the newLine handlebars helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bin/index.js",
   "scripts": {
     "test": "tsc && nodeunit ./test",
-    "prepublish": "npm test && mv ./src/theme.js ./bin"
+    "prepublish": "npm test && mv ./src/theme.js ./src/handlebars ./bin/"
   },
   "keywords": [
     "typescript"

--- a/src/handlebars/newLine.ts
+++ b/src/handlebars/newLine.ts
@@ -1,0 +1,3 @@
+export function newLine() {
+  return '\n';
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -25,7 +25,6 @@ export default class MarkdownTheme extends td.output.DefaultTheme {
     renderer.removePlugin('assets'); // markdown doesn't need assets
     renderer.removePlugin('javascriptIndex'); // markdown doesn't need search.js
     renderer.removePlugin('prettyPrint'); // new lines and spaces have meaning in markdown, don't omit them automatically!
-    Handlebars.registerHelper('newLine', () => '\n');
   }
 
   isOutputDirectory(path: string): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "./src/theme.ts",
+    "./src/handlebars/newLine.ts",
     "./test/theme_test.ts",
     "./typings/bundle.d.ts"
   ]


### PR DESCRIPTION
using `Handlebars.registerHelper` in `src/theme.ts` doesn't work, because typedoc looks for helpers in a different way.
typedoc scans the plugin directory for a helpers folder, where a js file should be placed which exports the helper function.
This should fix the newLine issue mentioned in #4.